### PR TITLE
docs: fix broken Build and deploy mods in VSCode link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Detailed walkthrough the creation of mods:
 
 ### Further Topics
 
-- [Build and deploy mods in VSCode](https://github.com/anno-mods/vscode-anno-modding-tools/blob/main/doc/annomod.md)  
+- [Build and deploy mods in VSCode](https://anno-mods.github.io/vscode-anno/tools/deploy/)  
 - [GU 17 update guide](./guides/gu17-update-guide.md)  
 - [GU 16 update guide](./guides/gu16-update-guide.md)
 - [**GuidRanges**](https://github.com/anno-mods/GuidRanges)


### PR DESCRIPTION
Repo vscode-anno-modding-tools was renamed to vscode-anno and doc/annomod.md was migrated to the MkDocs site. Point to the new Deploy Mods page.